### PR TITLE
Precompile quast dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER KBase Developer
 # Insert apt-get instructions here to install
 # any required dependencies for your module.
 
-RUN apt update && apt install -y  g++ nano tree
+# libz is for Minimap2 in Quast
+RUN apt update && apt install -y  g++ nano tree wget libz-dev
 
 RUN python -m pip install --upgrade pip \
     && pip install \
@@ -17,6 +18,16 @@ RUN python -m pip install --upgrade pip \
     && rm -r /opt/conda3/lib/python3.8/site-packages/quast_libs/genemark-es
 
 # Genemark is not open source for non-academic use, and so can't be used in KBase
+
+# Precompile dependencies vs compiling at first use
+# In particular, this allows the container to run @ NERSC
+RUN mkdir /quasttemp \
+    && cd /quasttemp \
+    && wget quast.sf.net/test_data.tar.gz \
+    && tar xzf test_data.tar.gz \
+    && quast.py --test --debug \
+    && cd - \
+    && rm -r /quasttemp
 
 # -----------------------------------------
 


### PR DESCRIPTION
Turns out that when you pip install the dependencies compile at first use, so they're compiling for every run. That being said, I don't think it takes very long; the real reason for this is that NERSC complains when QUAST tries to write to read only locations during compilation.